### PR TITLE
Optimization: Reduce Unnecessary Command Tree Sync Requests

### DIFF
--- a/main.py
+++ b/main.py
@@ -23,9 +23,6 @@ class DiscordClient(discord.Client):
 
     async def on_ready(self):
         await self.wait_until_ready()
-        if not self.synced:
-            await tree.sync()
-            self.synced = True
         log.info("Bot is online!")
 
 
@@ -40,6 +37,13 @@ def format_embed(embedded_message: discord.Embed) -> None:
 
 
 # Start of Slash Commands ------------------------------------------------------
+
+@tree.command(name="sync", description="Sync commands with Discord")
+@has_permissions(administrator=True)
+async def sync(interaction: discord.Interaction):
+    await tree.sync()
+    await interaction.response.send_message("Commands synced with Discord")
+
 @tree.command(
     name="info",
     description="Get server information",

--- a/main.py
+++ b/main.py
@@ -37,7 +37,6 @@ def format_embed(embedded_message: discord.Embed) -> None:
 
 
 # Start of Slash Commands ------------------------------------------------------
-
 @tree.command(name="sync", description="Sync commands with Discord")
 @has_permissions(administrator=True)
 async def sync(interaction: discord.Interaction):


### PR DESCRIPTION
**Invocation-Based Syncing**: The bot now syncs its command tree with Discord exclusively when the `sync` command is invoked, aligning with [best practices](https://discord.com/channels/336642139381301249/559455534965850142/1202484174079000627) guidance.

The `on_ready` function is triggered each time the bot connects or reconnects to Discord. If command syncing is placed within this function, it might lead to duplicate syncs, especially in cases of network instability or bot reconnections. This can result in redundant API calls and potential rate limit issues. Excessive command syncing can waste limited API resources and might even temporarily disable bot functionality if rate limits are exceeded. It also risks inconsistency in command availability if syncs are inadvertently triggered multiple times.

TL;DR: Updated command syncing to trigger only on command invocation, optimizing API usage and enhancing user experience.

Also [this](https://about.abstractumbra.dev/discord.py/2023/01/29/sync-command-example.html)